### PR TITLE
Deal with precompilation carefully

### DIFF
--- a/src/TensorDecompositions.jl
+++ b/src/TensorDecompositions.jl
@@ -1,4 +1,4 @@
-__precompile__()
+__precompile__(false)
 # require("TensorOperations")
 
 module TensorDecompositions
@@ -17,7 +17,7 @@ module TensorDecompositions
     # TensorDecomposition methods
     rel_residue,
     compose, compose!,
- 
+
     # additional tensor algebra methods
     tensorcontractmatrix, tensorcontractmatrices!, tensorcontractmatrices,
 


### PR DESCRIPTION
I know both TensorOperations and TensorDecompositions enabled precompilation a while ago(I found both cache files in my `.julia/lib/v0.5`), but now TensorOperations does not support precompilation anymore. As the doc says:

>`__precompile__()` should not be used in a module unless all of its dependencies are also using `__precompile__()`. Failure to do so can result in a runtime error when loading the module.

One may trigger the error when using TensorDecompositions in a clean machine:
```
julia> using TensorDecompositions
INFO: Precompiling module TensorDecompositions.
WARNING: Module TensorOperations with uuid 9683613277571 is missing from the cache.
This may mean module TensorOperations does not support precompilation but is imported by a module that does.
ERROR: LoadError: Declaring __precompile__(false) is not allowed in files that are being precompiled.
```
This error would not appear if someone had a pre-precompiled cache file in `.julia/lib/v0.5`.  Some related issues can be found [here](https://github.com/JuliaLang/julia/issues/19557) and [here](https://github.com/tbreloff/Plots.jl/pull/618), so we need to explicitly declare `__precompile__(false)`. 

CC: @yunjhongwu @jpfairbanks